### PR TITLE
fix: typo in footer's github link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
               <div class="footer-social wow fadeInUp" data-wow-delay="0.3s">
                 <a href="https://www.linkedin.com/company/zasper"><i class="fa fa-linkedin" aria-hidden="true"></i></a>
                 <a href="https://x.com/zasper_io/"><i class="fa fa-twitter" aria-hidden="true"></i></a>
-                <a href="https://github.com/zasperio"><i class="fa fa-github" aria-hidden="true"></i></a>
+                <a href="https://github.com/zasper-io"><i class="fa fa-github" aria-hidden="true"></i></a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
The github link in the footer is broken and points to zasperio instead of zasper-io. fixed it.

![image](https://github.com/user-attachments/assets/7bcd804f-10ba-4816-840c-3c08af23d850)
