### PR TITLE
fix v0.1 links in v0.2 versions

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -55,7 +55,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-darwin-arm64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-beta_arm64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -64,7 +64,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-darwin-amd64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_x64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-beta_x64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -73,7 +73,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-linux-amd64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_amd64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-beta_amd64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -82,7 +82,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-linux-arm64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-beta_arm64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -136,7 +136,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-windows-arm64.zip" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_win.exe" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-beta_arm64_win.exe" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>

--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -55,7 +55,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-darwin-arm64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.1.0-alpha_arm64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -64,7 +64,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-darwin-amd64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.1.0-alpha_x64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_x64_mac.dmg" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -73,7 +73,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-linux-amd64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.1.0-alpha_amd64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_amd64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -82,7 +82,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-linux-arm64.tar.gz" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.1.0-alpha_arm64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_linux.deb" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>
@@ -136,7 +136,7 @@
                 <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper-webapp-windows-arm64.zip" class="btn btn-bg" target="_blank">Download</a>
               </td>
               <td>
-                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.1.0-alpha_arm64_win.exe" class="btn btn-bg" target="_blank">Download</a>
+                <a href="https://github.com/zasper-io/zasper/releases/download/{{version}}/zasper_0.2.0-alpha_arm64_win.exe" class="btn btn-bg" target="_blank">Download</a>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
need to find a better way to map the version variable to the binary names.. not sure if it will always be a direct match like the `/{{version}}` slug